### PR TITLE
feat(r2-upload): add hold_period input for release gating

### DIFF
--- a/.github/workflows/_cloudflare-r2-upload.yaml
+++ b/.github/workflows/_cloudflare-r2-upload.yaml
@@ -212,53 +212,13 @@ jobs:
       # RELEASE MODE: Check hold period before proceeding
       - name: Check release hold period
         if: inputs.source_type == 'release' && inputs.hold_period > 0
+        uses: zondax/actions/release-hold@v1
         env:
           GH_TOKEN: ${{ github.token }}
-          HOLD_PERIOD: ${{ inputs.hold_period }}
-          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
-          REF_TYPE: ${{ github.ref_type }}
-          REPO: ${{ github.repository }}
-        run: |
-          RELEASE_TAG="$RELEASE_TAG_INPUT"
-          if [ -z "$RELEASE_TAG" ]; then
-            if [[ "$REF_TYPE" == "tag" ]]; then
-              RELEASE_TAG="${GITHUB_REF#refs/tags/}"
-            else
-              echo "❌ Error: release_tag is required when not running on a tag"
-              exit 1
-            fi
-          fi
-
-          # Get the most recent release asset upload time (= when last build finished)
-          LATEST_ASSET_AT=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets --jq '[.assets[].updatedAt] | sort | last')
-
-          if [ -z "$LATEST_ASSET_AT" ] || [ "$LATEST_ASSET_AT" = "null" ]; then
-            echo "⚠️ No assets found on release '$RELEASE_TAG'. Skipping hold check."
-            exit 0
-          fi
-
-          ASSET_EPOCH=$(date -d "$LATEST_ASSET_AT" +%s)
-          NOW_EPOCH=$(date +%s)
-
-          AGE_MINUTES=$(( (NOW_EPOCH - ASSET_EPOCH) / 60 ))
-
-          echo "⏱️ Release '$RELEASE_TAG' latest asset uploaded at: $LATEST_ASSET_AT"
-          echo "⏱️ Time since last asset: ${AGE_MINUTES} minutes"
-          echo "⏱️ Required hold period: ${HOLD_PERIOD} minutes"
-
-          if [ "$AGE_MINUTES" -lt "$HOLD_PERIOD" ]; then
-            REMAINING=$(( HOLD_PERIOD - AGE_MINUTES ))
-            echo ""
-            echo "🛑 HOLD PERIOD NOT MET"
-            echo "   Last asset was uploaded ${AGE_MINUTES}m ago, but ${HOLD_PERIOD}m required."
-            echo "   Please wait ~${REMAINING} more minutes, then re-run this job."
-            echo ""
-            echo "   This is intentional — download the binaries from the GitHub Release,"
-            echo "   test them locally, and re-run when ready."
-            exit 1
-          fi
-
-          echo "✅ Hold period satisfied (${AGE_MINUTES}m >= ${HOLD_PERIOD}m). Proceeding with upload."
+        with:
+          hold_period: '${{ inputs.hold_period }}'
+          anchor: release-asset
+          release_tag: '${{ inputs.release_tag }}'
 
       # Prepare upload directory (same for both modes)
       - name: Prepare upload directory

--- a/.github/workflows/_cloudflare-r2-upload.yaml
+++ b/.github/workflows/_cloudflare-r2-upload.yaml
@@ -217,6 +217,7 @@ jobs:
           HOLD_PERIOD: ${{ inputs.hold_period }}
           RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
           REF_TYPE: ${{ github.ref_type }}
+          REPO: ${{ github.repository }}
         run: |
           RELEASE_TAG="$RELEASE_TAG_INPUT"
           if [ -z "$RELEASE_TAG" ]; then
@@ -228,22 +229,28 @@ jobs:
             fi
           fi
 
-          # Get release creation timestamp
-          CREATED_AT=$(gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" --json createdAt --jq '.createdAt')
-          CREATED_EPOCH=$(date -d "$CREATED_AT" +%s)
+          # Get the most recent release asset upload time (= when last build finished)
+          LATEST_ASSET_AT=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets --jq '[.assets[].updatedAt] | sort | last')
+
+          if [ -z "$LATEST_ASSET_AT" ] || [ "$LATEST_ASSET_AT" = "null" ]; then
+            echo "⚠️ No assets found on release '$RELEASE_TAG'. Skipping hold check."
+            exit 0
+          fi
+
+          ASSET_EPOCH=$(date -d "$LATEST_ASSET_AT" +%s)
           NOW_EPOCH=$(date +%s)
 
-          AGE_MINUTES=$(( (NOW_EPOCH - CREATED_EPOCH) / 60 ))
+          AGE_MINUTES=$(( (NOW_EPOCH - ASSET_EPOCH) / 60 ))
 
-          echo "⏱️ Release '$RELEASE_TAG' created at: $CREATED_AT"
-          echo "⏱️ Release age: ${AGE_MINUTES} minutes"
+          echo "⏱️ Release '$RELEASE_TAG' latest asset uploaded at: $LATEST_ASSET_AT"
+          echo "⏱️ Time since last asset: ${AGE_MINUTES} minutes"
           echo "⏱️ Required hold period: ${HOLD_PERIOD} minutes"
 
           if [ "$AGE_MINUTES" -lt "$HOLD_PERIOD" ]; then
             REMAINING=$(( HOLD_PERIOD - AGE_MINUTES ))
             echo ""
             echo "🛑 HOLD PERIOD NOT MET"
-            echo "   Release is ${AGE_MINUTES}m old, but ${HOLD_PERIOD}m required."
+            echo "   Last asset was uploaded ${AGE_MINUTES}m ago, but ${HOLD_PERIOD}m required."
             echo "   Please wait ~${REMAINING} more minutes, then re-run this job."
             echo ""
             echo "   This is intentional — download the binaries from the GitHub Release,"

--- a/.github/workflows/_cloudflare-r2-upload.yaml
+++ b/.github/workflows/_cloudflare-r2-upload.yaml
@@ -89,7 +89,14 @@ on:
         required: false
         type: boolean
         default: true
-      
+
+      # Hold period (release gating)
+      hold_period:
+        description: 'Minimum age (in minutes) of the GitHub Release before upload is allowed. Only applies when source_type is release. 0 = no hold (default)'
+        required: false
+        type: number
+        default: 0
+
       # Environment
       environment:
         description: 'GitHub environment for secrets'
@@ -201,7 +208,51 @@ jobs:
           
           echo "📋 Downloaded files:"
           ls -la download/
-      
+
+      # RELEASE MODE: Check hold period before proceeding
+      - name: Check release hold period
+        if: inputs.source_type == 'release' && inputs.hold_period > 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HOLD_PERIOD: ${{ inputs.hold_period }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          RELEASE_TAG="$RELEASE_TAG_INPUT"
+          if [ -z "$RELEASE_TAG" ]; then
+            if [[ "$REF_TYPE" == "tag" ]]; then
+              RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+            else
+              echo "❌ Error: release_tag is required when not running on a tag"
+              exit 1
+            fi
+          fi
+
+          # Get release creation timestamp
+          CREATED_AT=$(gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" --json createdAt --jq '.createdAt')
+          CREATED_EPOCH=$(date -d "$CREATED_AT" +%s)
+          NOW_EPOCH=$(date +%s)
+
+          AGE_MINUTES=$(( (NOW_EPOCH - CREATED_EPOCH) / 60 ))
+
+          echo "⏱️ Release '$RELEASE_TAG' created at: $CREATED_AT"
+          echo "⏱️ Release age: ${AGE_MINUTES} minutes"
+          echo "⏱️ Required hold period: ${HOLD_PERIOD} minutes"
+
+          if [ "$AGE_MINUTES" -lt "$HOLD_PERIOD" ]; then
+            REMAINING=$(( HOLD_PERIOD - AGE_MINUTES ))
+            echo ""
+            echo "🛑 HOLD PERIOD NOT MET"
+            echo "   Release is ${AGE_MINUTES}m old, but ${HOLD_PERIOD}m required."
+            echo "   Please wait ~${REMAINING} more minutes, then re-run this job."
+            echo ""
+            echo "   This is intentional — download the binaries from the GitHub Release,"
+            echo "   test them locally, and re-run when ready."
+            exit 1
+          fi
+
+          echo "✅ Hold period satisfied (${AGE_MINUTES}m >= ${HOLD_PERIOD}m). Proceeding with upload."
+
       # Prepare upload directory (same for both modes)
       - name: Prepare upload directory
         run: |

--- a/.github/workflows/_cloudflare-r2-upload.yaml
+++ b/.github/workflows/_cloudflare-r2-upload.yaml
@@ -92,10 +92,16 @@ on:
 
       # Hold period (release gating)
       hold_period:
-        description: 'Minimum age (in minutes) of the GitHub Release before upload is allowed. Only applies when source_type is release. 0 = no hold (default)'
+        description: 'Minimum age (in minutes) before upload is allowed. Works with both release and artifacts source types. 0 = no hold (default)'
         required: false
         type: number
         default: 0
+
+      hold_artifact_name:
+        description: 'Artifact name to check creation time for hold period (artifacts mode only). If empty, falls back to run-start anchor.'
+        required: false
+        type: string
+        default: ''
 
       # Environment
       environment:
@@ -219,6 +225,17 @@ jobs:
           hold_period: '${{ inputs.hold_period }}'
           anchor: release-asset
           release_tag: '${{ inputs.release_tag }}'
+
+      # ARTIFACTS MODE: Check hold period before proceeding
+      - name: Check artifacts hold period
+        if: inputs.source_type == 'artifacts' && inputs.hold_period > 0
+        uses: zondax/actions/release-hold@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          hold_period: '${{ inputs.hold_period }}'
+          anchor: ${{ inputs.hold_artifact_name != '' && 'artifact' || 'run-start' }}
+          artifact_name: '${{ inputs.hold_artifact_name }}'
 
       # Prepare upload directory (same for both modes)
       - name: Prepare upload directory


### PR DESCRIPTION
## Value
- **Release safety gate** — new optional `hold_period` input allows consumers to enforce a minimum age on GitHub Releases before R2 upload proceeds
- **Zero breaking changes** — defaults to 0 (no hold), so all existing consumers work identically

## Technical
- Modified `.github/workflows/_cloudflare-r2-upload.yaml` to add `hold_period` input (number, default 0)
- Added "Check release hold period" step between release download and upload preparation
- Only activates when `source_type == 'release'` AND `hold_period > 0`
- Uses `gh release view` to get release creation timestamp, fails with clear message showing remaining wait time
- All GitHub context expressions passed via `env:` variables (no direct interpolation in `run:` blocks)