### PR TITLE
Fix Rust home env setup

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -109,10 +109,6 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: setup
     runs-on: ${{ matrix.runner }}
-    env:
-      CARGO_HOME: ${{ runner.temp }}/cargo
-      RUSTUP_HOME: ${{ runner.temp }}/rustup
-      RUSTUP_INIT_SKIP_PATH_CHECK: "yes"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
@@ -120,6 +116,12 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Configure isolated Rust homes
+        run: |
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+          echo "RUSTUP_INIT_SKIP_PATH_CHECK=yes" >> "$GITHUB_ENV"
+
       - name: Checkout with GitHub App
         uses: zondax/actions/checkout-with-app@v1
         with:


### PR DESCRIPTION
Follow-up to #84. The previous fix used the runner context in job-level env, which causes startup_failure before jobs are created. This moves the isolated CARGO_HOME/RUSTUP_HOME setup into a step that writes RUNNER_TEMP-based paths to GITHUB_ENV before rust-toolchain runs.