### PR TITLE
Install targets on active Rust toolchain

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -136,6 +136,11 @@ jobs:
           toolchain: ${{ inputs.rust_toolchain }}
           targets: ${{ matrix.target }}
 
+      - name: Install target for active Rust toolchain
+        env:
+          TARGET: ${{ matrix.target }}
+        run: rustup target add "$TARGET"
+
       - name: Install cross
         if: matrix.use_cross
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
This makes the release workflow run rustup target add for the active toolchain after checkout/toolchain setup. Repos with rust-toolchain.toml overrides, such as kache pinning 1.95, otherwise install the target for stable but build with the pinned toolchain.