### PR TITLE
feat(ledger): replace yarn install with corepack for zemu test step

### DIFF
--- a/.github/workflows/_ledger_main.yml
+++ b/.github/workflows/_ledger_main.yml
@@ -215,10 +215,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-      - name: Install yarn
-        run: npm install -g yarn
-      - name: Clean yarn cache
-        run: yarn cache clean
+      - name: Enable corepack (pnpm version is pinned in zxlib's dockerized_build.mk)
+        run: corepack enable
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
         with:


### PR DESCRIPTION
Drop the global yarn install and rely on corepack to provision the package manager declared in each app's tests_zemu/package.json `packageManager` field. Unblocks migration to pnpm 11, whose stricter postinstall-script policy is the supply-chain reason for the switch.
Breaking change for caller apps still on yarn — they must add a `packageManager` pin and a pnpm lockfile before consuming this version.
