### PR TITLE
fix(release): mark semver pre-release tags as pre-releases

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -275,15 +275,15 @@ jobs:
             if [ "${{ inputs.release_draft }}" = "true" ]; then
               DRAFT_FLAG="--draft"
             fi
-            # A semver pre-release tag carries a hyphen in the version
-            # (e.g. v1.2.0-rc1, v1.2.0-beta.3). Mark those as
-            # pre-releases and keep "Latest" pinned to the most recent
-            # stable tag — otherwise an RC silently becomes the latest
-            # release that `@latest` installers and the release badge
-            # resolve to.
+            # Tags carrying a known pre-release identifier (rc, alpha,
+            # beta, pre/preview, dev) are published as pre-releases,
+            # with "Latest" left pinned to the most recent stable tag
+            # — otherwise an RC silently becomes the release that
+            # `@latest` installers and the release badge resolve to.
             PRERELEASE_FLAG=""
             case "$TAG_NAME" in
-              *-*) PRERELEASE_FLAG="--prerelease --latest=false" ;;
+              *-rc*|*-alpha*|*-beta*|*-pre*|*-dev*)
+                PRERELEASE_FLAG="--prerelease --latest=false" ;;
             esac
             gh release create "$TAG_NAME" $DRAFT_FLAG $PRERELEASE_FLAG --generate-notes
           fi

--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -275,7 +275,17 @@ jobs:
             if [ "${{ inputs.release_draft }}" = "true" ]; then
               DRAFT_FLAG="--draft"
             fi
-            gh release create "$TAG_NAME" $DRAFT_FLAG --generate-notes
+            # A semver pre-release tag carries a hyphen in the version
+            # (e.g. v1.2.0-rc1, v1.2.0-beta.3). Mark those as
+            # pre-releases and keep "Latest" pinned to the most recent
+            # stable tag — otherwise an RC silently becomes the latest
+            # release that `@latest` installers and the release badge
+            # resolve to.
+            PRERELEASE_FLAG=""
+            case "$TAG_NAME" in
+              *-*) PRERELEASE_FLAG="--prerelease --latest=false" ;;
+            esac
+            gh release create "$TAG_NAME" $DRAFT_FLAG $PRERELEASE_FLAG --generate-notes
           fi
           # Upload assets (--clobber overwrites existing)
           gh release upload "$TAG_NAME" artifacts/* --clobber


### PR DESCRIPTION
## Problem

`_release-rust.yml` creates the GitHub Release with:

```sh
gh release create "$TAG_NAME" $DRAFT_FLAG --generate-notes
```

No `--prerelease` flag, no `--latest` handling. So **every** tag — including release candidates like `v0.3.0-rc2` — becomes a normal, non-prerelease release that `gh` also promotes to **"Latest"**.

Real impact (seen on `kunobi-ninja/kache` `v0.3.0-rc2`): the RC displaced the last stable release as "Latest", so `mise install …@latest` and the `releases/latest` README badge would have served release-candidate code as the default. It had to be corrected by hand with `gh release edit --prerelease --latest=false`.

## Fix

When the tag carries a known pre-release identifier — `rc`, `alpha`, `beta`, `pre`/`preview`, `dev` — create the release with `--prerelease --latest=false`:

```sh
PRERELEASE_FLAG=""
case "$TAG_NAME" in
  *-rc*|*-alpha*|*-beta*|*-pre*|*-dev*)
    PRERELEASE_FLAG="--prerelease --latest=false" ;;
esac
gh release create "$TAG_NAME" $DRAFT_FLAG $PRERELEASE_FLAG --generate-notes
```

An explicit identifier allowlist, rather than "any hyphen in the tag" — so component-prefixed or date-style tags are not misclassified. Stable tags are unaffected; RC/beta tags are now classified correctly and "Latest" stays pinned to the most recent stable release.

## Test plan

- [ ] Tag a stable `vX.Y.Z` -> release is normal + "Latest".
- [ ] Tag a `vX.Y.Z-rc1` -> release is marked pre-release, "Latest" unchanged.