### PR TITLE
ci: bump artifact actions to node24 (upload/download v4→v7)

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -232,7 +232,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.binary_name }}-${{ matrix.target }}
           retention-days: 1
@@ -256,7 +256,7 @@ jobs:
           app_pem: ${{ secrets.app_pem }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
`actions/upload-artifact@v4` and `actions/download-artifact@v4` run on the deprecated **Node 20** runtime, force-migrated to Node 24 on GitHub runners from **2026-06-16**.

Bumped both to **v7** — the lowest matched major where both are node24 (`upload-artifact@v5` and `download-artifact@v5/v6` are still node20). v7/v7 is a matched pair on the same v4+ artifact backend.

This is the binary build+upload path every `_release-rust.yml` consumer runs on a tag; without this it would hit the forced node24 migration unmanaged. Consumers pinned to `@main` (e.g. kunobi-ninja/kache) pick this up on merge.