### PR TITLE
fix(release-rust): install zip for Windows-msvc packaging + cap build timeout

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -135,6 +135,9 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: setup
     runs-on: ${{ matrix.runner }}
+    # Cap a single target's build so a hang (e.g. a stalled cargo-xwin CRT/SDK
+    # download) fails fast instead of running to GitHub's 6h default.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
@@ -192,13 +195,15 @@ jobs:
       # lld-link against the MSVC CRT + Windows SDK that `xwin` downloads, using
       # clang/clang-cl as the C/C++ compiler. nasm + cmake are needed by native
       # deps (aws-lc-sys, ring) whose build scripts assemble/cmake C for the
-      # target. Runs on the Linux build host (only reached when use_xwin=true).
+      # target. `zip` is needed by the Package step (Windows artifacts are .zip,
+      # and the Linux host has no `zip` by default). Runs on the Linux build host
+      # (only reached when use_xwin=true).
       - name: Install xwin toolchain (Windows-msvc cross)
         if: matrix.use_xwin
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            clang lld llvm nasm cmake
+            clang lld llvm nasm cmake zip
       - name: Install cargo-xwin
         if: matrix.use_xwin
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
Follow-up to #94. First real release run (`kache v0.5.0-rc.2`) revealed two issues with the cargo-xwin Windows path on self-hosted Linux runners:

1. **`zip: command not found`** in the Package step. The `cargo-xwin` build of `-pc-windows-msvc` *succeeds* (CRT/SDK download, `aws-lc-sys` compile, link, strip all pass), but Windows artifacts are `.zip` and the Linux host has no `zip`. → add `zip` to the xwin toolchain install step.
2. **No build timeout.** Add `timeout-minutes: 45` so a stalled CRT/SDK download fails fast instead of burning toward GitHub's 6h cap. (Observed ~16 min CRT downloads on `kunobi-runners` — slow egress to Microsoft's CDN; not fatal, but worth bounding.)

The build itself is proven working on `kunobi-runners` — only packaging failed.

Retag `v9` to this commit after merge (kache pins `@v9`).