### PR TITLE
feat(_release-rust): opt-in GCP-KMS code signing

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -67,6 +67,75 @@ on:
         required: false
         type: string
         default: ""
+      # --- Code signing (opt-in; default off → no change for existing callers) ---
+      enable_signing:
+        description: "Enable OS code signing of built binaries"
+        required: false
+        type: boolean
+        default: false
+      notarize_macos:
+        description: "Submit macOS binaries for Apple notarization"
+        required: false
+        type: boolean
+        default: true
+      # CODESIGN_* identity — used for Windows Authenticode (KMS) AND to fetch the
+      # Apple signing creds from GCP Secret Manager (macOS). One identity, both jobs.
+      codesign_wif_provider:
+        description: "WIF provider for code signing (vars.CODESIGN_WIF_PROVIDER)"
+        required: false
+        type: string
+        default: ""
+      codesign_gcp_project:
+        description: "GCP project for code signing + Apple Secret Manager (vars.CODESIGN_GCP_PROJECT)"
+        required: false
+        type: string
+        default: ""
+      codesign_service_account:
+        description: "Service account to impersonate (vars.CODESIGN_SERVICE_ACCOUNT); empty = direct WIF"
+        required: false
+        type: string
+        default: ""
+      codesign_kms_keyring:
+        description: "Authenticode KMS keyring (vars.CODESIGN_KMS_KEYRING)"
+        required: false
+        type: string
+        default: ""
+      codesign_kms_key_alias:
+        description: "Authenticode KMS key alias (vars.CODESIGN_KMS_KEY_ALIAS)"
+        required: false
+        type: string
+        default: ""
+      jsign_sha256:
+        description: "Pinned sha256 of the jsign jar"
+        required: false
+        type: string
+        default: ""
+      rcodesign_sha256:
+        description: "Pinned sha256 of the rcodesign tarball"
+        required: false
+        type: string
+        default: ""
+      # PGP_SIGN_* identity — Linux detached OpenPGP via GCP KMS
+      pgp_sign_wif_provider:
+        description: "WIF provider for OpenPGP KMS (vars.PGP_SIGN_WIF_PROVIDER)"
+        required: false
+        type: string
+        default: ""
+      pgp_sign_gcp_project_id:
+        description: "GCP project for OpenPGP KMS (vars.PGP_SIGN_GCP_PROJECT_ID)"
+        required: false
+        type: string
+        default: ""
+      pgp_sign_service_account:
+        description: "Service account for OpenPGP KMS (vars.PGP_SIGN_SERVICE_ACCOUNT)"
+        required: false
+        type: string
+        default: ""
+      pgp_sign_kms_key_version:
+        description: "OpenPGP KMS key version path (vars.PGP_SIGN_KMS_KEY_VERSION)"
+        required: false
+        type: string
+        default: ""
     secrets:
       app_id:
         description: "GitHub App ID"
@@ -74,9 +143,21 @@ on:
       app_pem:
         description: "GitHub App PEM"
         required: false
+      # Code-signing secrets. NOTE: no Apple secrets — macOS creds live in GCP
+      # Secret Manager (fetched via the CODESIGN_* identity).
+      pgp_cert_base64:
+        description: "Base64 OpenPGP public cert (Linux)"
+        required: false
+      pgp_signer_token:
+        description: "Token (GitHub App or PAT) with read on private kunobi-ninja/kunobi-pgp-kms"
+        required: false
+      windows_cert_chain:
+        description: "PKCS7 EV certificate chain (Windows Authenticode)"
+        required: false
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   # --- Job 1: Compute build matrix from target list ---
@@ -212,7 +293,13 @@ jobs:
           LLVM_VERSION: "21"
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl nasm cmake zip
+          # build-essential = the HOST toolchain: build scripts and proc-macros
+          # link with `cc` (gcc) on the Linux runner, independently of the Windows
+          # cross compiler. The distro `clang` install used to drag gcc in
+          # transitively; pulling clang from apt.llvm.org no longer does, and the
+          # self-hosted runner has no gcc preinstalled — so install it explicitly
+          # or host build scripts fail with `linker 'cc' not found`.
+          sudo apt-get install -y --no-install-recommends build-essential curl nasm cmake zip
           # Modern clang/lld from apt.llvm.org (distro clang-18 is too old — see above).
           curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s -- "$LLVM_VERSION"
           sudo apt-get install -y --no-install-recommends \
@@ -310,6 +397,56 @@ jobs:
             strip "$BIN"
           fi
 
+      # --- Code signing: all platforms sign the BINARY before packaging.
+      #     macOS/Windows embed the signature in the binary; Linux produces a
+      #     detached .asc that gets bundled into the archive next to the binary. ---
+      - name: Sign macOS binary
+        if: inputs.enable_signing && contains(matrix.target, 'apple-darwin')
+        uses: zondax/actions/sign-macos-binary@v1.2.0
+        with:
+          binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
+          workload-identity-provider: ${{ inputs.codesign_wif_provider }}
+          gcp-project: ${{ inputs.codesign_gcp_project }}
+          service-account: ${{ inputs.codesign_service_account }}
+          notarize: ${{ inputs.notarize_macos }}
+          rcodesign-sha256: ${{ inputs.rcodesign_sha256 }}
+
+      - name: Authenticate with GCP (Authenticode)
+        id: auth-codesign
+        if: inputs.enable_signing && contains(matrix.target, 'windows')
+        uses: zondax/actions/gcp-wif-auth@v1.2.0
+        with:
+          workload_identity_provider: ${{ inputs.codesign_wif_provider }}
+          project_id: ${{ inputs.codesign_gcp_project }}
+          service_account: ${{ inputs.codesign_service_account }}
+          token_format: access_token
+          create_credentials_file: 'false'
+          setup_gcloud: 'false'
+          verify_authentication: 'false'
+
+      - name: Sign Windows binary
+        if: inputs.enable_signing && contains(matrix.target, 'windows')
+        uses: zondax/actions/sign-windows-binary@v1.2.0
+        with:
+          binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}.exe
+          gcp-access-token: ${{ steps.auth-codesign.outputs.access_token }}
+          kms-keyring: ${{ inputs.codesign_kms_keyring }}
+          kms-key-alias: ${{ inputs.codesign_kms_key_alias }}
+          cert-chain: ${{ secrets.windows_cert_chain }}
+          jsign-sha256: ${{ inputs.jsign_sha256 }}
+
+      - name: Sign Linux binary
+        if: inputs.enable_signing && contains(matrix.target, 'linux')
+        uses: zondax/actions/sign-linux-binary@v1.2.0
+        with:
+          target-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
+          workload-identity-provider: ${{ inputs.pgp_sign_wif_provider }}
+          gcp-project-id: ${{ inputs.pgp_sign_gcp_project_id }}
+          service-account: ${{ inputs.pgp_sign_service_account }}
+          signer-token: ${{ secrets.pgp_signer_token }}
+          kms-key: ${{ inputs.pgp_sign_kms_key_version }}
+          cert-base64: ${{ secrets.pgp_cert_base64 }}
+
       - name: Package
         env:
           TARGET: ${{ matrix.target }}
@@ -329,8 +466,30 @@ jobs:
               (cd "target/$TARGET/release" && zip "$OLDPWD/$ARCHIVE" "${BINARY_NAME}${BINARY_EXT}")
             fi
           else
-            tar czf "$ARCHIVE" -C "target/$TARGET/release" "${BINARY_NAME}${BINARY_EXT}"
+            # Bundle the detached .asc (Linux binary signing) into the tarball
+            # next to the binary, so the signature travels with what it signs.
+            ASC="${BINARY_NAME}${BINARY_EXT}.asc"
+            if [ -f "target/$TARGET/release/$ASC" ]; then
+              tar czf "$ARCHIVE" -C "target/$TARGET/release" "${BINARY_NAME}${BINARY_EXT}" "$ASC"
+            else
+              tar czf "$ARCHIVE" -C "target/$TARGET/release" "${BINARY_NAME}${BINARY_EXT}"
+            fi
           fi
+
+      # Linux ALSO signs the packaged archive (detached .asc, top-level release
+      # asset) — in addition to the binary's .asc bundled inside it. Two PGP sigs:
+      # one over the ELF (inside the tarball), one over the .tar.gz (download).
+      - name: Sign Linux archive
+        if: inputs.enable_signing && contains(matrix.target, 'linux')
+        uses: zondax/actions/sign-linux-binary@v1.2.0
+        with:
+          target-path: ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          workload-identity-provider: ${{ inputs.pgp_sign_wif_provider }}
+          gcp-project-id: ${{ inputs.pgp_sign_gcp_project_id }}
+          service-account: ${{ inputs.pgp_sign_service_account }}
+          signer-token: ${{ secrets.pgp_signer_token }}
+          kms-key: ${{ inputs.pgp_sign_kms_key_version }}
+          cert-base64: ${{ secrets.pgp_cert_base64 }}
 
       - name: Checksum
         env:
@@ -358,6 +517,7 @@ jobs:
           path: |
             ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
             ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}.sha256
+            ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}.asc
 
   # --- Job 3: Create/upload GitHub Release ---
   release:

--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -387,7 +387,7 @@ jobs:
       #     detached .asc that gets bundled into the archive next to the binary. ---
       - name: Sign macOS binary
         if: inputs.enable_signing && contains(matrix.target, 'apple-darwin')
-        uses: zondax/actions/sign-macos-binary@feat/code-signing
+        uses: zondax/actions/sign-macos-binary@v1
         with:
           binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
           workload-identity-provider: ${{ secrets.codesign_wif_provider }}
@@ -399,7 +399,7 @@ jobs:
       - name: Authenticate with GCP (Authenticode)
         id: auth-codesign
         if: inputs.enable_signing && contains(matrix.target, 'windows')
-        uses: zondax/actions/gcp-wif-auth@feat/code-signing
+        uses: zondax/actions/gcp-wif-auth@v1
         with:
           workload_identity_provider: ${{ secrets.codesign_wif_provider }}
           project_id: ${{ secrets.codesign_gcp_project }}
@@ -411,7 +411,7 @@ jobs:
 
       - name: Sign Windows binary
         if: inputs.enable_signing && contains(matrix.target, 'windows')
-        uses: zondax/actions/sign-windows-binary@feat/code-signing
+        uses: zondax/actions/sign-windows-binary@v1
         with:
           binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}.exe
           gcp-access-token: ${{ steps.auth-codesign.outputs.access_token }}
@@ -422,7 +422,7 @@ jobs:
 
       - name: Sign Linux binary
         if: inputs.enable_signing && contains(matrix.target, 'linux')
-        uses: zondax/actions/sign-linux-binary@feat/code-signing
+        uses: zondax/actions/sign-linux-binary@v1
         with:
           target-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
           workload-identity-provider: ${{ secrets.pgp_sign_wif_provider }}
@@ -466,7 +466,7 @@ jobs:
       # one over the ELF (inside the tarball), one over the .tar.gz (download).
       - name: Sign Linux archive
         if: inputs.enable_signing && contains(matrix.target, 'linux')
-        uses: zondax/actions/sign-linux-binary@feat/code-signing
+        uses: zondax/actions/sign-linux-binary@v1
         with:
           target-path: ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           workload-identity-provider: ${{ secrets.pgp_sign_wif_provider }}

--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -402,7 +402,7 @@ jobs:
       #     detached .asc that gets bundled into the archive next to the binary. ---
       - name: Sign macOS binary
         if: inputs.enable_signing && contains(matrix.target, 'apple-darwin')
-        uses: zondax/actions/sign-macos-binary@v1.2.0
+        uses: zondax/actions/sign-macos-binary@feat/code-signing
         with:
           binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
           workload-identity-provider: ${{ inputs.codesign_wif_provider }}
@@ -414,7 +414,7 @@ jobs:
       - name: Authenticate with GCP (Authenticode)
         id: auth-codesign
         if: inputs.enable_signing && contains(matrix.target, 'windows')
-        uses: zondax/actions/gcp-wif-auth@v1.2.0
+        uses: zondax/actions/gcp-wif-auth@feat/code-signing
         with:
           workload_identity_provider: ${{ inputs.codesign_wif_provider }}
           project_id: ${{ inputs.codesign_gcp_project }}
@@ -426,7 +426,7 @@ jobs:
 
       - name: Sign Windows binary
         if: inputs.enable_signing && contains(matrix.target, 'windows')
-        uses: zondax/actions/sign-windows-binary@v1.2.0
+        uses: zondax/actions/sign-windows-binary@feat/code-signing
         with:
           binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}.exe
           gcp-access-token: ${{ steps.auth-codesign.outputs.access_token }}
@@ -437,7 +437,7 @@ jobs:
 
       - name: Sign Linux binary
         if: inputs.enable_signing && contains(matrix.target, 'linux')
-        uses: zondax/actions/sign-linux-binary@v1.2.0
+        uses: zondax/actions/sign-linux-binary@feat/code-signing
         with:
           target-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
           workload-identity-provider: ${{ inputs.pgp_sign_wif_provider }}
@@ -481,7 +481,7 @@ jobs:
       # one over the ELF (inside the tarball), one over the .tar.gz (download).
       - name: Sign Linux archive
         if: inputs.enable_signing && contains(matrix.target, 'linux')
-        uses: zondax/actions/sign-linux-binary@v1.2.0
+        uses: zondax/actions/sign-linux-binary@feat/code-signing
         with:
           target-path: ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           workload-identity-provider: ${{ inputs.pgp_sign_wif_provider }}

--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -78,33 +78,10 @@ on:
         required: false
         type: boolean
         default: true
-      # CODESIGN_* identity — used for Windows Authenticode (KMS) AND to fetch the
-      # Apple signing creds from GCP Secret Manager (macOS). One identity, both jobs.
-      codesign_wif_provider:
-        description: "WIF provider for code signing (vars.CODESIGN_WIF_PROVIDER)"
-        required: false
-        type: string
-        default: ""
-      codesign_gcp_project:
-        description: "GCP project for code signing + Apple Secret Manager (vars.CODESIGN_GCP_PROJECT)"
-        required: false
-        type: string
-        default: ""
-      codesign_service_account:
-        description: "Service account to impersonate (vars.CODESIGN_SERVICE_ACCOUNT); empty = direct WIF"
-        required: false
-        type: string
-        default: ""
-      codesign_kms_keyring:
-        description: "Authenticode KMS keyring (vars.CODESIGN_KMS_KEYRING)"
-        required: false
-        type: string
-        default: ""
-      codesign_kms_key_alias:
-        description: "Authenticode KMS key alias (vars.CODESIGN_KMS_KEY_ALIAS)"
-        required: false
-        type: string
-        default: ""
+      # NOTE: the CODESIGN_*/PGP_SIGN_* config values are declared under `secrets:`
+      # below (not here). Callers in public repos store them as secrets, and the
+      # `secrets` context cannot be referenced from a reusable-workflow `with:` —
+      # so they must be passed through the `secrets:` block.
       jsign_sha256:
         description: "Pinned sha256 of the jsign jar"
         required: false
@@ -112,27 +89,6 @@ on:
         default: ""
       rcodesign_sha256:
         description: "Pinned sha256 of the rcodesign tarball"
-        required: false
-        type: string
-        default: ""
-      # PGP_SIGN_* identity — Linux detached OpenPGP via GCP KMS
-      pgp_sign_wif_provider:
-        description: "WIF provider for OpenPGP KMS (vars.PGP_SIGN_WIF_PROVIDER)"
-        required: false
-        type: string
-        default: ""
-      pgp_sign_gcp_project_id:
-        description: "GCP project for OpenPGP KMS (vars.PGP_SIGN_GCP_PROJECT_ID)"
-        required: false
-        type: string
-        default: ""
-      pgp_sign_service_account:
-        description: "Service account for OpenPGP KMS (vars.PGP_SIGN_SERVICE_ACCOUNT)"
-        required: false
-        type: string
-        default: ""
-      pgp_sign_kms_key_version:
-        description: "OpenPGP KMS key version path (vars.PGP_SIGN_KMS_KEY_VERSION)"
         required: false
         type: string
         default: ""
@@ -153,6 +109,35 @@ on:
         required: false
       windows_cert_chain:
         description: "PKCS7 EV certificate chain (Windows Authenticode)"
+        required: false
+      # CODESIGN_*/PGP_SIGN_* config — passed as secrets (callers in public repos
+      # keep these out of Variables; secrets can't ride in a reusable-workflow `with:`).
+      codesign_wif_provider:
+        description: "WIF provider for code signing (Windows Authenticode + Apple Secret Manager)"
+        required: false
+      codesign_gcp_project:
+        description: "GCP project for code signing + Apple Secret Manager"
+        required: false
+      codesign_service_account:
+        description: "Service account to impersonate; empty = direct WIF"
+        required: false
+      codesign_kms_keyring:
+        description: "Authenticode KMS keyring"
+        required: false
+      codesign_kms_key_alias:
+        description: "Authenticode KMS key alias"
+        required: false
+      pgp_sign_wif_provider:
+        description: "WIF provider for OpenPGP KMS (Linux)"
+        required: false
+      pgp_sign_gcp_project_id:
+        description: "GCP project for OpenPGP KMS"
+        required: false
+      pgp_sign_service_account:
+        description: "Service account for OpenPGP KMS"
+        required: false
+      pgp_sign_kms_key_version:
+        description: "OpenPGP KMS key version path"
         required: false
 
 permissions:
@@ -405,9 +390,9 @@ jobs:
         uses: zondax/actions/sign-macos-binary@feat/code-signing
         with:
           binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
-          workload-identity-provider: ${{ inputs.codesign_wif_provider }}
-          gcp-project: ${{ inputs.codesign_gcp_project }}
-          service-account: ${{ inputs.codesign_service_account }}
+          workload-identity-provider: ${{ secrets.codesign_wif_provider }}
+          gcp-project: ${{ secrets.codesign_gcp_project }}
+          service-account: ${{ secrets.codesign_service_account }}
           notarize: ${{ inputs.notarize_macos }}
           rcodesign-sha256: ${{ inputs.rcodesign_sha256 }}
 
@@ -416,9 +401,9 @@ jobs:
         if: inputs.enable_signing && contains(matrix.target, 'windows')
         uses: zondax/actions/gcp-wif-auth@feat/code-signing
         with:
-          workload_identity_provider: ${{ inputs.codesign_wif_provider }}
-          project_id: ${{ inputs.codesign_gcp_project }}
-          service_account: ${{ inputs.codesign_service_account }}
+          workload_identity_provider: ${{ secrets.codesign_wif_provider }}
+          project_id: ${{ secrets.codesign_gcp_project }}
+          service_account: ${{ secrets.codesign_service_account }}
           token_format: access_token
           create_credentials_file: 'false'
           setup_gcloud: 'false'
@@ -430,8 +415,8 @@ jobs:
         with:
           binary-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}.exe
           gcp-access-token: ${{ steps.auth-codesign.outputs.access_token }}
-          kms-keyring: ${{ inputs.codesign_kms_keyring }}
-          kms-key-alias: ${{ inputs.codesign_kms_key_alias }}
+          kms-keyring: ${{ secrets.codesign_kms_keyring }}
+          kms-key-alias: ${{ secrets.codesign_kms_key_alias }}
           cert-chain: ${{ secrets.windows_cert_chain }}
           jsign-sha256: ${{ inputs.jsign_sha256 }}
 
@@ -440,11 +425,11 @@ jobs:
         uses: zondax/actions/sign-linux-binary@feat/code-signing
         with:
           target-path: target/${{ matrix.target }}/release/${{ inputs.binary_name }}
-          workload-identity-provider: ${{ inputs.pgp_sign_wif_provider }}
-          gcp-project-id: ${{ inputs.pgp_sign_gcp_project_id }}
-          service-account: ${{ inputs.pgp_sign_service_account }}
+          workload-identity-provider: ${{ secrets.pgp_sign_wif_provider }}
+          gcp-project-id: ${{ secrets.pgp_sign_gcp_project_id }}
+          service-account: ${{ secrets.pgp_sign_service_account }}
           signer-token: ${{ secrets.pgp_signer_token }}
-          kms-key: ${{ inputs.pgp_sign_kms_key_version }}
+          kms-key: ${{ secrets.pgp_sign_kms_key_version }}
           cert-base64: ${{ secrets.pgp_cert_base64 }}
 
       - name: Package
@@ -484,11 +469,11 @@ jobs:
         uses: zondax/actions/sign-linux-binary@feat/code-signing
         with:
           target-path: ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
-          workload-identity-provider: ${{ inputs.pgp_sign_wif_provider }}
-          gcp-project-id: ${{ inputs.pgp_sign_gcp_project_id }}
-          service-account: ${{ inputs.pgp_sign_service_account }}
+          workload-identity-provider: ${{ secrets.pgp_sign_wif_provider }}
+          gcp-project-id: ${{ secrets.pgp_sign_gcp_project_id }}
+          service-account: ${{ secrets.pgp_sign_service_account }}
           signer-token: ${{ secrets.pgp_signer_token }}
-          kms-key: ${{ inputs.pgp_sign_kms_key_version }}
+          kms-key: ${{ secrets.pgp_sign_kms_key_version }}
           cert-base64: ${{ secrets.pgp_cert_base64 }}
 
       - name: Checksum


### PR DESCRIPTION
**Draft — part 2 of a 3-repo code-signing rollout.** Depends on `Zondax/actions` PR #12 (references its actions at `@v1.2.0`).

## What
Adds **opt-in** OS code signing to `_release-rust.yml`, default **off** (no change for existing callers):

- `id-token: write` added to the workflow's own top-level `permissions:` (the ceiling — callers can't grant it otherwise).
- New inputs (`enable_signing`, `notarize_macos`, Apple/CODESIGN/PGP config, `jsign_sha256`, `rcodesign_sha256`) and signing `secrets:`.
- `build` job: sign macOS (`rcodesign`) + Windows (`jsign`/KMS) **before Package**; sign the Linux **archive** (`.asc`) **after Package**; upload the `.asc`.
- Windows GCP auth uses `gcp-wif-auth@v1.2.0` with `token_format: access_token`, `create_credentials_file:false`, `setup_gcloud:false`, `verify_authentication:false` (token-only).

## Rollout / dependency
1. `Zondax/actions` #12 → tag `v1.2.0`.
2. **This PR** → merge → tag **`v10`** (carries `runner_windows` #93 + signing).
3. `kunobi-ninja/kache` bumps to `_workflows@v10`.

## Notes
- `actionlint` clean (only pre-existing SC2086/SC2129 warnings).
- WIF must be scoped (per-repo allowlist incl. `kunobi-ninja/kache`, tag-push only) before any real signed run — infra prerequisite, not in this PR.