### PR TITLE
ci(release-rust): shim clang for ring .S asm under cargo-xwin (unblocks aarch64-pc-windows-msvc)

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -210,6 +210,46 @@ jobs:
         with:
           tool: cargo-xwin
 
+      # cargo-xwin compiles C/C++ with clang-cl, but cc-rs falls back to the GNU
+      # `clang` driver to assemble crates that ship GNU `.S` files (e.g. ring's
+      # aarch64 asm). That fallback inherits clang-cl's `/imsvc` MSVC-include
+      # flags, which the GNU driver rejects ("unknown argument" / treats `/imsvc`
+      # as a missing file) — so the build dies, or 44min-hangs were really
+      # masking it. Shim `clang` (the bare name cc-rs invokes via PATH) to
+      # rewrite each `/imsvc` token to `-isystem` (the GNU spelling) and exec the
+      # real clang. Transparent otherwise; clang-cl (used for C) is NOT shadowed,
+      # so NEON codegen for zstd/blake3 etc. stays correct. Needed for
+      # aarch64-pc-windows-msvc; harmless for x86_64 (no clang `.S` step there).
+      - name: Shim clang for ring .S asm under cargo-xwin
+        if: matrix.use_xwin
+        run: |
+          SHIM_DIR="$RUNNER_TEMP/xwin-clang-shim"
+          mkdir -p "$SHIM_DIR"
+          cat > "$SHIM_DIR/clang" <<'SHIM'
+          #!/bin/sh
+          # Resolve the real clang: first `clang` on PATH that isn't this shim.
+          self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+          real=""
+          IFS=:
+          for d in $PATH; do
+            [ "$d" = "$self_dir" ] && continue
+            if [ -x "$d/clang" ]; then real="$d/clang"; break; fi
+          done
+          unset IFS
+          [ -n "$real" ] || { echo "xwin-clang-shim: real clang not found on PATH" >&2; exit 127; }
+          # Rebuild argv, translating clang-cl's `/imsvc` -> GNU `-isystem`.
+          n=0
+          for a in "$@"; do
+            [ "$a" = "/imsvc" ] && a="-isystem"
+            eval "arg_$n=\$a"; n=$((n+1))
+          done
+          i=0; set --
+          while [ "$i" -lt "$n" ]; do eval "v=\$arg_$i"; set -- "$@" "$v"; i=$((i+1)); done
+          exec "$real" "$@"
+          SHIM
+          chmod +x "$SHIM_DIR/clang"
+          echo "$SHIM_DIR" >> "$GITHUB_PATH"
+
       - name: Set extra environment
         if: inputs.extra_build_env != ''
         env:


### PR DESCRIPTION
## Problem

`cargo-xwin` cross-builds `-pc-windows-msvc` using **clang-cl** for C/C++. But `cc-rs` falls back to the **GNU `clang` driver** to assemble crates that ship GNU `.S` files — notably **`ring`**'s aarch64 asm (`armv8-mont-win64.S`, `p256-armv8-asm-win64.S`, …). That fallback inherits clang-cl's `/imsvc` MSVC-include flags, which the GNU driver rejects:

```
clang: error: unknown argument: '-imsvc'      # (or treats /imsvc as a missing file)
```

This makes `aarch64-pc-windows-msvc` impossible to cross-build for any Rust project depending on ring (rustls-with-ring, etc.). In `kache` it manifested as the arm64-Windows release job hanging 44min then cancelling (the hang was aws-lc-sys; removing it surfaced this clang issue underneath).

## Fix

A small step (gated on `matrix.use_xwin`) installs a `clang` shim on `PATH` that rewrites each `/imsvc` token to `-isystem` (the GNU-driver spelling) and execs the real clang. It resolves the real clang by scanning `PATH` for the first `clang` outside its own dir, so it's self-contained.

- **`clang-cl` is NOT shadowed** — C/C++ compiles still go through the real clang-cl, so NEON codegen for `zstd-sys` / `blake3` stays correct (the GNU driver miscompiles arm64-Windows NEON; clang-cl doesn't).
- **Harmless for x86_64-pc-windows-msvc** — ring uses NASM there, so the clang `.S` path isn't hit; the shim is a transparent passthrough.

## Validation

Cross-compiled `kache` (rustls + **ring**, no aws-lc-sys) from macOS via cargo-xwin:
- `aarch64-pc-windows-msvc` → ✅ clean build, ~1m11s, real ARM64 PE produced
- `x86_64-pc-windows-msvc` → ✅ unaffected, ~1m12s

## Rollout

`kache` pins `@v9`. Once this merges, please **retag `v9`** (or cut the next major) so consumers pick it up — kache's `aarch64-pc-windows-msvc` release depends on it.