### PR TITLE
ci(release-rust): use clang/lld 21 from apt.llvm.org for xwin cross-build

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -198,12 +198,30 @@ jobs:
       # target. `zip` is needed by the Package step (Windows artifacts are .zip,
       # and the Linux host has no `zip` by default). Runs on the Linux build host
       # (only reached when use_xwin=true).
+      #
+      # clang/lld come from apt.llvm.org, NOT the distro: Ubuntu's default clang-18
+      # mis-compiles two bundled C deps when cross-targeting Windows-msvc — x86_64
+      # leaves zstd-sys's SSE2 intrinsics (`_mm_*`) as undefined symbols at link,
+      # and aarch64 rejects the MSVC `<intrin.h>` ("conflicting types for
+      # '__prefetch'", pulled in by zstd-sys + libsqlite3-sys). A modern clang
+      # fixes both (verified: clang-22 builds both targets cleanly, clang-18 fails
+      # both). Bump LLVM_VERSION here to roll the toolchain forward.
       - name: Install xwin toolchain (Windows-msvc cross)
         if: matrix.use_xwin
+        env:
+          LLVM_VERSION: "21"
         run: |
           sudo apt-get update
+          sudo apt-get install -y --no-install-recommends curl nasm cmake zip
+          # Modern clang/lld from apt.llvm.org (distro clang-18 is too old — see above).
+          curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s -- "$LLVM_VERSION"
           sudo apt-get install -y --no-install-recommends \
-            clang lld llvm nasm cmake zip
+            "clang-$LLVM_VERSION" "lld-$LLVM_VERSION" "llvm-$LLVM_VERSION"
+          # cargo-xwin and the ring `.S` shim invoke unversioned tool names via PATH;
+          # point them at the freshly installed toolchain.
+          for t in clang clang++ clang-cl lld-link llvm-lib llvm-rc llvm-ar llvm-ranlib llvm-nm llvm-dlltool; do
+            sudo ln -sf "/usr/lib/llvm-$LLVM_VERSION/bin/$t" "/usr/local/bin/$t"
+          done
       - name: Install cargo-xwin
         if: matrix.use_xwin
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Problem

The `-pc-windows-msvc` release targets built via cargo-xwin have **never linked** — the `release` job only runs on tag pushes, so PR CI never exercised them. Both fail in bundled C deps because Ubuntu's default **clang-18** mis-compiles them when cross-targeting Windows-msvc:

- **x86_64**: zstd-sys's SSE2 intrinsics (`_mm_loadu_si128`, `_mm_cmpeq_epi8`, `_mm_movemask_epi8`, …) are left as undefined symbols → `lld-link: undefined symbol`.
- **aarch64**: the MSVC `<intrin.h>` is rejected with `conflicting types for '__prefetch'` (pulled in by zstd-sys and libsqlite3-sys / rusqlite `bundled`).

## Fix

Install clang/lld **21** from apt.llvm.org instead of the distro's clang-18, and repoint the unversioned tool names that cargo-xwin and the ring `.S` shim resolve via PATH.

## Verification

Reproduced locally with a faithful cargo-xwin + xwin-SDK + ring-`.S`-shim replica of CI, varying only the clang version:

| Target | clang-18 (CI) | clang-22 (local) |
|---|---|---|
| x86_64-pc-windows-msvc | undefined `_mm_*` at link | ✅ PE32+ x86-64 binary |
| aarch64-pc-windows-msvc | `__prefetch` conflicting types | ✅ PE32+ Aarch64 binary |

Scoped to the `if: matrix.use_xwin` step — only affects Windows-msvc cross-builds.