### PR TITLE
ci(release-rust): install build-essential for the xwin host toolchain

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -212,7 +212,13 @@ jobs:
           LLVM_VERSION: "21"
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl nasm cmake zip
+          # build-essential = the HOST toolchain: build scripts and proc-macros
+          # link with `cc` (gcc) on the Linux runner, independently of the Windows
+          # cross compiler. The distro `clang` install used to drag gcc in
+          # transitively; pulling clang from apt.llvm.org no longer does, and the
+          # self-hosted runner has no gcc preinstalled — so install it explicitly
+          # or host build scripts fail with `linker 'cc' not found`.
+          sudo apt-get install -y --no-install-recommends build-essential curl nasm cmake zip
           # Modern clang/lld from apt.llvm.org (distro clang-18 is too old — see above).
           curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s -- "$LLVM_VERSION"
           sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Follow-up to #99. The xwin cross job builds **host** crates (build scripts, proc-macros) that link with `cc` (gcc) on the Linux runner — separate from the Windows cross compiler.

Before #99, installing the distro `clang` pulled `gcc`/`make` in transitively. Sourcing clang from apt.llvm.org with `--no-install-recommends` no longer does, and the self-hosted runner has no gcc preinstalled — so host build scripts now fail with `linker 'cc' not found` (proc-macro2, quote) before the cross compile even starts.

Fix: install `build-essential` explicitly alongside the cross toolchain. Confirmed root cause in the v0.5.1-rc.3 run: rc.2's log shows `gcc make` pulled in transitively by the old distro clang install; rc.3 (apt.llvm.org clang) has no gcc → `cc` not found.