### PR TITLE
feat(_release-rust): opt-in Debian .deb build

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -67,6 +67,12 @@ on:
         required: false
         type: string
         default: ""
+      # --- Debian packaging (opt-in; default off → no change for existing callers) ---
+      build_deb:
+        description: "Build a Debian .deb package for Linux targets via cargo-deb (opt-in; default off). Requires the consumer Cargo.toml to define [package.metadata.deb] with depends = \"\" for static-musl binaries."
+        required: false
+        type: boolean
+        default: false
       # --- Code signing (opt-in; default off → no change for existing callers) ---
       enable_signing:
         description: "Enable OS code signing of built binaries"
@@ -494,15 +500,81 @@ jobs:
               > "${ARCHIVE}.sha256"
           fi
 
+      # --- Debian package (opt-in; Linux targets only). Builds a .deb from the
+      #     ALREADY-built binary (--no-build → no recompile), packaged AFTER the
+      #     strip + binary-signing steps above so the .deb carries the stripped,
+      #     signed ELF. The .deb is then PGP-signed (detached .asc) and checksummed
+      #     exactly like the tar.gz assets, and uploaded as a top-level release
+      #     asset named kache_<version>_<arch>.deb.
+      #
+      # NOTE: the CONSUMING repo must define `[package.metadata.deb]` in its
+      # Cargo.toml with `depends = ""` (the static-musl binary has no shared-lib
+      # deps) — otherwise `cargo deb` runs dpkg-shlibdeps and fails. We do NOT add
+      # any Cargo metadata here; that belongs to the consumer's repo.
+      - name: Install cargo-deb
+        if: inputs.build_deb && contains(matrix.target, 'linux')
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deb
+
+      - name: Build Debian package
+        id: deb
+        if: inputs.build_deb && contains(matrix.target, 'linux')
+        env:
+          TARGET: ${{ matrix.target }}
+          # Derive <version> from the release tag the same git ref the release job
+          # uploads under (github.ref_name), dropping a leading "v": v1.2.3 → 1.2.3.
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          # Map the Rust musl triple to the Debian arch used in the asset name.
+          case "$TARGET" in
+            x86_64-unknown-linux-musl)  ARCH="amd64" ;;
+            aarch64-unknown-linux-musl) ARCH="arm64" ;;
+            *) echo "Unsupported Linux target for .deb: $TARGET" >&2; exit 1 ;;
+          esac
+          DEB="kache_${VERSION}_${ARCH}.deb"
+          # --no-build → package the binary already built/stripped/signed above.
+          cargo deb --no-build --target "$TARGET" --output "$DEB"
+          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+
+      - name: Sign Debian package
+        if: inputs.build_deb && contains(matrix.target, 'linux')
+        uses: zondax/actions/sign-linux-binary@v1
+        with:
+          target-path: ${{ steps.deb.outputs.deb }}
+          workload-identity-provider: ${{ secrets.pgp_sign_wif_provider }}
+          gcp-project-id: ${{ secrets.pgp_sign_gcp_project_id }}
+          service-account: ${{ secrets.pgp_sign_service_account }}
+          signer-token: ${{ secrets.pgp_signer_token }}
+          kms-key: ${{ secrets.pgp_sign_kms_key_version }}
+          cert-base64: ${{ secrets.pgp_cert_base64 }}
+
+      - name: Checksum Debian package
+        if: inputs.build_deb && contains(matrix.target, 'linux')
+        env:
+          DEB: ${{ steps.deb.outputs.deb }}
+        run: |
+          if command -v sha256sum &>/dev/null; then
+            sha256sum "$DEB" > "${DEB}.sha256"
+          else
+            shasum -a 256 "$DEB" > "${DEB}.sha256"
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.binary_name }}-${{ matrix.target }}
           retention-days: 1
+          # The .deb globs are no-ops on non-Linux / when build_deb is off
+          # (upload-artifact tolerates missing globbed paths).
           path: |
             ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
             ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}.sha256
             ${{ inputs.binary_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}.asc
+            *.deb
+            *.deb.sha256
+            *.deb.asc
 
   # --- Job 3: Create/upload GitHub Release ---
   release:


### PR DESCRIPTION
## What

Adds an **opt-in Debian `.deb` build** to the reusable `_release-rust.yml` workflow, mirroring the existing `enable_signing` opt-in pattern.

## How

- New `workflow_call` input **`build_deb`** (boolean, `required: false`, **default `false`**). Default off → 100% backward-compatible, so **`v10` can keep floating to main**.
- All new steps are gated on `inputs.build_deb && contains(matrix.target, 'linux')`.
- Installs **cargo-deb** via `taiki-e/install-action@v2` (`tool: cargo-deb`).
- Builds with `cargo deb --no-build --target ${{ matrix.target }} --output <deb>` — **no recompile**; it packages the binary already built/stripped/signed earlier in the job.
- Per-arch: `x86_64-unknown-linux-musl → amd64`, `aarch64-unknown-linux-musl → arm64`.
- Asset named **`kache_<version>_<arch>.deb`**, where `<version>` = `github.ref_name` with a leading `v` stripped (the same ref the release job uploads under).
- **Signed** with the same `zondax/actions/sign-linux-binary@v1` action and identical secrets as the other Linux assets → produces `<deb>.asc`.
- **Checksummed** (`<deb>.sha256`) like every other asset.
- The `.deb`, `.deb.asc`, `.deb.sha256` are uploaded through the **same** `upload-artifact` → `gh release upload` mechanism as the rest.

## Consumer requirement

The consuming repo's `Cargo.toml` must define:

```toml
[package.metadata.deb]
depends = ""   # static musl binary → no shared-lib deps; avoids dpkg-shlibdeps failure
```

No Cargo metadata is added here — that belongs to the consumer repo.

## Merge order

Merge this **and move `v10`** BEFORE the `kache` repo passes `build_deb: true`.