### PR TITLE
fix(npm): correct OIDC diagnostic + document trusted-publishing limitation

### DIFF
--- a/.github/workflows/_publish-npm.yaml
+++ b/.github/workflows/_publish-npm.yaml
@@ -1,7 +1,16 @@
 name: Reusable Publish NPM
 
-# Uses OIDC Trusted Publishing - no tokens needed
-# Configure trusted publisher on npmjs.com for your package
+# ⚠️ npm OIDC Trusted Publishing does NOT work through this reusable workflow.
+# npm validates the OIDC `job_workflow_ref` claim, which for a reusable workflow
+# is THIS file (zondax/_workflows/.github/workflows/_publish-npm.yaml) — not the
+# caller's workflow. A package's Trusted Publisher can only name one repo +
+# workflow (e.g. Zondax/cli + publish-npm.yaml), so a publish performed here can
+# never match it and npm returns `E404 ... is not in this registry`.
+# (Verified: @zondax/cli only published once its publish ran in its OWN workflow.)
+#
+# To publish to npm with OIDC, run `npm publish` in the package repo's own
+# workflow (see Zondax/cli/.github/workflows/publish-npm.yaml). This workflow is
+# still usable for token-based publishing if a token is wired in.
 # See: https://docs.npmjs.com/trusted-publishers/
 
 on:
@@ -154,14 +163,21 @@ jobs:
           node --version
           echo ""
           echo "=== OIDC Token Info ==="
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL is set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN is set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
+          # NOTE: read these from the shell, NOT `${{ env.* }}`. The `env`
+          # context only exposes variables declared via `env:` blocks; the
+          # runner-injected OIDC vars are not in it, so `${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}`
+          # always evaluates to empty and prints a misleading "false".
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL is set: $([ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && echo true || echo false)"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN is set: $([ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] && echo true || echo false)"
           echo ""
           echo "=== GitHub Context ==="
           echo "Repository: ${{ github.repository }}"
           echo "Workflow: ${{ github.workflow }}"
+          # workflow_ref = entry-point (caller) workflow; job_workflow_ref = the
+          # workflow that actually contains this job (THIS reusable file). npm
+          # trusted publishing matches on job_workflow_ref — see the header note.
           echo "Workflow ref: ${{ github.workflow_ref }}"
-          echo "Job workflow ref: ${{ github.job_workflow_sha }}"
+          echo "Job workflow ref: ${{ github.job_workflow_ref }}"
           echo "Run ID: ${{ github.run_id }}"
 
       - name: Publish package


### PR DESCRIPTION
## Context

`@zondax/cli` releases kept failing with `npm error E404 ... '@zondax/cli@x.y.z' is not in this registry` when publishing through `_publish-npm.yaml`, despite a correctly-configured npm Trusted Publisher. This PR fixes the misleading diagnostic that sent us down the wrong path, and documents the underlying limitation (now verified).

## What this PR changes (safe, non-behavioral)

1. **Fix the OIDC diagnostic.** `Debug OIDC environment` read `${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}` / `_TOKEN`. The `env` *context* only exposes `env:`-declared vars, **not** runner-injected OIDC vars — so it **always** printed `is set: false`, even when the token was present. We chased a phantom "no OIDC token" for hours because of this. Now read from the shell (`[ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]`).
2. **Print `github.job_workflow_ref`** (the claim npm actually validates) instead of the empty `github.job_workflow_sha`.
3. **Header note** documenting that OIDC trusted publishing can't work through this reusable workflow.

## The real finding (verified)

npm trusted publishing validates the OIDC **`job_workflow_ref`** — the workflow file that runs `npm publish`. For a reusable workflow that's **this file** (`zondax/_workflows/.github/workflows/_publish-npm.yaml`), not the caller. A package's Trusted Publisher can only name **one** repo + workflow (e.g. `Zondax/cli` · `publish-npm.yaml`), so a publish performed here can never match it → `E404`.

**Proof:** `@zondax/cli` failed every publish through this reusable workflow (v7 and v10), then **published successfully (`1.14.1`) the moment its `npm publish` ran in its own repo workflow** (`Zondax/cli/.github/workflows/publish-npm.yaml`) with `id-token: write`.

## OIDC vs token — strategy options (org decision)

| Option | How | Trade-off |
|---|---|---|
| **A. Self-contained per-package publish (recommended)** | Each package runs `npm publish` in its **own** workflow with `id-token: write`; keep OIDC trusted publishing (no tokens). `Zondax/cli` already does this. | Matches the "no tokens" intent; a few lines of YAML per repo (can be templated). Reusable workflow no longer used for npm publish. |
| **B. Reusable workflow + token** | Add an `npm_token` secret input here and auth with `NODE_AUTH_TOKEN`. | Keeps one shared workflow, but reintroduces long-lived tokens per package — the thing trusted publishing removed. |

**Recommendation: A.** I'm happy to add a documented self-contained `publish-npm.yaml` template (mirroring cli's) and either deprecate npm publishing from this reusable workflow or gate it behind a token input — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)