### PR TITLE
fix(ledger): re-checkout app/rust/.cargo/config.toml after Rust cache restore

### DIFF
--- a/.github/workflows/_ledger_main.yml
+++ b/.github/workflows/_ledger_main.yml
@@ -121,6 +121,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-${{ runner.arch }}-
             ${{ runner.os }}-rust-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        if: ${{ inputs.has-rust }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: Install rust-src component
         if: ${{ inputs.has-rust }}
         run: rustup component add rust-src --toolchain ${{ inputs.rust-version }}-x86_64-unknown-linux-gnu
@@ -268,6 +276,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-${{ runner.arch }}-
             ${{ runner.os }}-rust-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        if: ${{ inputs.has-rust }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: Install rust-src component
         if: ${{ inputs.has-rust }}
         run: rustup component add rust-src --toolchain ${{ inputs.rust-version }}-x86_64-unknown-linux-gnu
@@ -342,6 +358,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-${{ runner.arch }}-
             ${{ runner.os }}-rust-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        if: ${{ inputs.has-rust }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: Install rust-src component
         if: ${{ inputs.has-rust }}
         run: rustup component add rust-src --toolchain ${{ inputs.rust-version }}-x86_64-unknown-linux-gnu
@@ -416,6 +440,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-${{ runner.arch }}-
             ${{ runner.os }}-rust-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        if: ${{ inputs.has-rust }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: Install rust-src component
         if: ${{ inputs.has-rust }}
         run: rustup component add rust-src --toolchain ${{ inputs.rust-version }}-x86_64-unknown-linux-gnu
@@ -489,6 +521,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-${{ runner.arch }}-
             ${{ runner.os }}-rust-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        if: ${{ inputs.has-rust }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: Install rust-src component
         if: ${{ inputs.has-rust }}
         run: rustup component add rust-src --toolchain ${{ inputs.rust-version }}-x86_64-unknown-linux-gnu
@@ -562,6 +602,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-${{ runner.arch }}-
             ${{ runner.os }}-rust-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        if: ${{ inputs.has-rust }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: Install rust-src component
         if: ${{ inputs.has-rust }}
         run: rustup component add rust-src --toolchain ${{ inputs.rust-version }}-x86_64-unknown-linux-gnu


### PR DESCRIPTION
The Rust dependency cache in `_ledger_main.yml` stores `${cargo_home}` =
`app/rust/.cargo`, which includes the **tracked** `config.toml`. `actions/cache`
restores it *after* `actions/checkout`, so a cache produced before the
nightly migration overwrites the checked-out `config.toml` with a
pre-migration copy that still sets `build-std-features = ["panic_immediate_abort"]`.
`nightly-2025-12-05` rejects that (it is now the `immediate-abort` panic
strategy, not a build-std feature), so `build_ledger` / `build_package_*`
fail with `could not compile core`.

This bit every app adopting the nightly/immediate-abort migration
(app-icp #54, app-avalanche #61, app-oasis #34): the change builds fine
locally and in `zondax/ledger-app-builder:latest` with a clean cargo, but
CI restored the poisoned cache over it.

**Fix:** after each Rust cache restore, re-checkout the committed
`config.toml` from `HEAD` so the in-repo config always wins. Works even
with the existing poisoned caches (no cache deletion needed) and is a
no-op for apps without a tracked `app/rust/.cargo/config.toml`.

Note: the moving `v3` tag was already force-moved to this commit to
unblock the in-flight PRs; this PR lands the same fix on `main` so it is
not lost if `v3` is recut.