### PR TITLE
fix(ledger): re-checkout cargo config in clippy/rust_tests jobs too

### DIFF
--- a/.github/workflows/_ledger_main.yml
+++ b/.github/workflows/_ledger_main.yml
@@ -158,6 +158,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ runner.arch }}-
             ${{ runner.os }}-cargo-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: clippy
         run: |
           cd ./app/rust
@@ -182,6 +189,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ runner.arch }}-
             ${{ runner.os }}-cargo-
+      - name: Restore tracked cargo config (cache may carry a pre-migration copy)
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch app/rust/.cargo/config.toml >/dev/null 2>&1; then
+            git -C "$GITHUB_WORKSPACE" checkout -- app/rust/.cargo/config.toml
+            echo "Restored app/rust/.cargo/config.toml from checkout (a stale Rust cache can overwrite it with a pre-migration copy)."
+          fi
       - name: run rust tests
         run: |
           cd ./app/rust


### PR DESCRIPTION
Follow-up to the build_ledger/build_package cache-clobber fix. The `clippy` and `rust_tests` jobs also cache `./app/rust/.cargo` (incl. the tracked `config.toml`); a pre-migration cache restores an old `config.toml` with `build-std` over the checkout. Once an app moves its host toolchain to nightly (immediate-abort via Cargo.toml profile), that stale `build-std` rebuilds host `core` → `E0152: duplicate lang item`.

Adds the same post-restore `git checkout -- app/rust/.cargo/config.toml` to both jobs. `v3` tag moved to this commit. Surfaced by Zondax/ledger-icp#332.