### PR TITLE
fix(_pulumi-wif): pin mise to known-good version (default 2026.5.18)

### DIFF
--- a/.github/workflows/_pulumi-wif.yaml
+++ b/.github/workflows/_pulumi-wif.yaml
@@ -56,6 +56,11 @@ on:
         description: "Command to initialize environment (without package manager prefix)"
         type: string
         default: "env:init:ci"
+      mise_version:
+        description: "mise version for jdx/mise-action to install. Pinned to a known-good release because mise 2026.6.x mis-verifies pulumi's linux-x64 aqua checksum (CI: 'verified checksum file digest does not match existing checksum'). Override per-repo if needed."
+        required: false
+        type: string
+        default: "2026.5.18"
     secrets:
       app_id:
         description: "GitHub App ID"
@@ -123,6 +128,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
         with:
+          version: ${{ inputs.mise_version }}
           install: true
           cache: false
           cache_save: false


### PR DESCRIPTION
## Problem
When `jdx/mise-action` installs mise unpinned, it pulls **mise 2026.6.x**, which mis-verifies pulumi's linux-x64 aqua checksum. Every consumer's `pulumi` CI fails at `Setup mise`:
```
mise ERROR Failed to install aqua:pulumi/pulumi@latest:
  verified checksum file digest does not match existing checksum
  for pulumi-v<ver>-linux-x64.tar.gz
```
Verified it's a mise regression, not pulumi/registry:
- The real `pulumi-v3.247.0-linux-x64.tar.gz` hashes to `1924bbd…` = exactly pulumi's signed checksum.
- The live aqua-registry pulumi entry has no pinned checksum (`aqua.baked_registry=false` still fails).
- mise **2026.5.x** installs pulumi cleanly; **2026.6.x** does not.

This is fleet-wide: any repo using `_pulumi-wif` breaks the next time its pulumi CI runs (e.g. kunobi-iac is failing today; others just haven't re-run since pulumi 3.247.0 dropped on Jun 18).

## Fix
Add an optional `mise_version` input (default **`2026.5.18`**, last known-good line) and pass it to `jdx/mise-action`'s `version`.

**Backward compatible** — existing callers need no change and automatically get the working pin; any repo can override via the new input. Remove the pin (set `mise_version: ""`) once mise ships a fixed release.