### PR TITLE
fix(_checks-ts): pin mise to known-good version (mirror #107)

### DIFF
--- a/.github/workflows/_checks-ts.yaml
+++ b/.github/workflows/_checks-ts.yaml
@@ -152,6 +152,11 @@ on:
         description: "Cache pnpm store to S3 (disable for dedicated/persistent runners)"
         type: boolean
         default: true
+      mise_version:
+        description: "mise version for jdx/mise-action to install. Pinned to a known-good release because mise 2026.6.x mis-verifies pulumi's linux-x64 aqua checksum (CI: 'verified checksum file digest does not match existing checksum'). Override per-repo if needed."
+        required: false
+        type: string
+        default: "2026.5.18"
     secrets:
       app_id:
         description: "GitHub App ID"
@@ -233,6 +238,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
         with:
+          version: ${{ inputs.mise_version }}
           install: true
           cache: false
           cache_save: false


### PR DESCRIPTION
## Problem

`CI-ts` jobs fail at `mise install` for any consumer whose `mise.toml` lists `pulumi` (e.g. `infra-iac`, `kunobi-iac`):

```
mise ERROR Failed to install aqua:pulumi/pulumi@<ver>:
verified checksum file digest does not match existing checksum
for pulumi-v<ver>-linux-x64.tar.gz
```

## Root cause

`jdx/mise-action`, when unpinned, installs the latest mise. **mise 2026.6.x** (2026.6.12, released 2026-06-22) mis-verifies Pulumi's linux-x64 aqua checksum — confirmed against the last green run, which used **mise 2026.6.11** and installed Pulumi fine. aqua checksum verification is always-on and can't be disabled, so the only fix is pinning mise to a known-good release. This is a mise 2026.6 regression, not a Pulumi/registry issue.

#107 already fixed this for `_pulumi-wif.yaml`. This PR applies the **same fix** to `_checks-ts.yaml`, which was missed and also runs `mise install`.

## Change

Add the optional `mise_version` input (default `2026.5.18`, last known-good) and pass it to `mise-action`'s `version`. Backward compatible — existing callers get the working pin automatically and can override per-repo. Revert once the mise regression is fixed upstream.

> [!NOTE]
> Consumers (`infra-iac`, `kunobi-iac`) currently pin `@v5`, which predates both this fix and #107. They must bump their `uses:` ref to the tag containing these fixes for CI to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)