### PR TITLE
feat(_release-rust): product-generic .deb path (binary_name + optional -p)

### DIFF
--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -4,8 +4,12 @@ on:
   workflow_call:
     inputs:
       binary_name:
-        description: "Name of the binary to build (used for archive naming: {name}-{target}.tar.gz)"
-        required: true
+        # Defaults to "kache" so this workflow stays a strict no-op for the
+        # original (kache) behavior when a caller omits it — archive/.exe/.deb
+        # naming all fall back to kache. New consumers (e.g. kobe) set it.
+        description: "Name of the binary to build (archive/.deb naming: {name}-{target}). Defaults to kache for backward-compatibility."
+        required: false
+        default: kache
         type: string
       targets:
         description: "JSON array of Rust target triples to build"
@@ -556,9 +560,11 @@ jobs:
         id: deb
         if: inputs.build_deb && contains(matrix.target, 'linux')
         env:
-          TARGET: ${{ matrix.target }}
-          BINARY_NAME: ${{ inputs.binary_name }}
+          # Falls back to kache (also the input default) so an unset/empty
+          # binary_name reproduces the original hardcoded `kache_…deb` name.
+          BINARY_NAME: ${{ inputs.binary_name || 'kache' }}
           DEB_PACKAGE: ${{ inputs.deb_package }}
+          TARGET: ${{ matrix.target }}
           # Derive <version> from the release tag the same git ref the release job
           # uploads under (github.ref_name), dropping a leading "v": v1.2.3 → 1.2.3.
           VERSION: ${{ github.ref_name }}

--- a/.github/workflows/_release-rust.yml
+++ b/.github/workflows/_release-rust.yml
@@ -73,6 +73,11 @@ on:
         required: false
         type: boolean
         default: false
+      deb_package:
+        description: "Cargo package selector (`-p`) for the .deb build. Set this for workspace consumers whose packaged crate is a workspace member (e.g. \"kobe-ctl\"). Empty (default) → no `-p`, packaging the root package as before (e.g. kache)."
+        required: false
+        type: string
+        default: ""
       upload_windows_exe:
         description: "Also publish the bare signed .exe per Windows target as a first-class release asset (binary_name-<triple>.exe + .sha256), in addition to the .zip. Opt-in; default off. Lets winget install it as InstallerType: portable."
         required: false
@@ -535,7 +540,7 @@ jobs:
       #     strip + binary-signing steps above so the .deb carries the stripped,
       #     signed ELF. The .deb is then PGP-signed (detached .asc) and checksummed
       #     exactly like the tar.gz assets, and uploaded as a top-level release
-      #     asset named kache_<version>_<arch>.deb.
+      #     asset named <binary_name>_<version>_<arch>.deb (e.g. kache_… or kobe_…).
       #
       # NOTE: the CONSUMING repo must define `[package.metadata.deb]` in its
       # Cargo.toml with `depends = ""` (the static-musl binary has no shared-lib
@@ -552,6 +557,8 @@ jobs:
         if: inputs.build_deb && contains(matrix.target, 'linux')
         env:
           TARGET: ${{ matrix.target }}
+          BINARY_NAME: ${{ inputs.binary_name }}
+          DEB_PACKAGE: ${{ inputs.deb_package }}
           # Derive <version> from the release tag the same git ref the release job
           # uploads under (github.ref_name), dropping a leading "v": v1.2.3 → 1.2.3.
           VERSION: ${{ github.ref_name }}
@@ -563,9 +570,10 @@ jobs:
             aarch64-unknown-linux-musl) ARCH="arm64" ;;
             *) echo "Unsupported Linux target for .deb: $TARGET" >&2; exit 1 ;;
           esac
-          DEB="kache_${VERSION}_${ARCH}.deb"
+          DEB="${BINARY_NAME}_${VERSION}_${ARCH}.deb"
           # --no-build → package the binary already built/stripped/signed above.
-          cargo deb --no-build --target "$TARGET" --output "$DEB"
+          # `-p $DEB_PACKAGE` only when set (workspace member); empty → root package.
+          cargo deb --no-build ${DEB_PACKAGE:+-p "$DEB_PACKAGE"} --target "$TARGET" --output "$DEB"
           echo "deb=$DEB" >> "$GITHUB_OUTPUT"
 
       - name: Sign Debian package


### PR DESCRIPTION
## What

Makes the Debian `.deb` build step in the reusable workflow `.github/workflows/_release-rust.yml` **product-generic**, instead of hardcoding kache.

Two changes to the `Build Debian package` step:

1. **Deb filename derives from `inputs.binary_name`** — `${BINARY_NAME}_${VERSION}_${ARCH}.deb` instead of the literal `kache_…`. `BINARY_NAME: ${{ inputs.binary_name }}` is added to the step `env:`.
2. **New optional input `deb_package`** (string, default `""`). When set, `-p "$DEB_PACKAGE"` is passed to `cargo deb` via `${DEB_PACKAGE:+-p "$DEB_PACKAGE"}`; when empty, the command runs exactly as today (no `-p`).

```diff
-          DEB="kache_${VERSION}_${ARCH}.deb"
-          cargo deb --no-build --target "$TARGET" --output "$DEB"
+          DEB="${BINARY_NAME}_${VERSION}_${ARCH}.deb"
+          cargo deb --no-build ${DEB_PACKAGE:+-p "$DEB_PACKAGE"} --target "$TARGET" --output "$DEB"
```

The signing / notarize / bare-exe / build steps are **untouched**.

## Backward compatibility (kache)

100% backward-compatible for the existing consumer `kunobi-ninja/kache`:

- kache's `binary_name` is `kache`, so `${BINARY_NAME}_…` → `kache_<version>_<arch>.deb` — **identical asset name**.
- kache does not set `deb_package`, so it defaults to `""` → `${DEB_PACKAGE:+…}` expands to nothing → `cargo deb` runs **exactly as before** (no `-p`, root package).

No behavior change for any current caller.

## What it unblocks

Cargo-**workspace** consumers whose CLI lives in a member crate. e.g. `kunobi-ninja/kobe`: binary `kobe`, built from `-p kobe-ctl`, producing `kobe_<version>_<arch>.deb`. It only needs `binary_name: kobe` + `deb_package: kobe-ctl`.

## Notes

- `actionlint` passes on the changed step (the few shellcheck infos it reports are **pre-existing** on unrelated steps, not introduced here).
- **Versioning:** a new tag (e.g. `v12`) should be cut **after** kache's release path is re-verified green against this branch, so workspace consumers can pin to it.